### PR TITLE
fix(ci): sequence deploy workflows after quality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,15 @@ on:
       - main
       - production
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
 
 permissions:
-  actions: read
+  actions: write
   contents: read
   statuses: write
 
@@ -49,3 +55,51 @@ jobs:
 
       - name: Build
         run: yarn build
+
+  dispatch_deploy_preview_main:
+    needs: quality
+    if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch Deploy Preview DB
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --url "https://api.github.com/repos/${{ github.repository }}/actions/workflows/deploy-preview.yml/dispatches" \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer $GITHUB_TOKEN" \
+            --data '{"ref":"main","inputs":{"checkout_ref":"${{ github.sha }}"}}'
+
+  dispatch_deploy_production:
+    needs: quality
+    if: ${{ github.event_name == 'push' && github.ref_name == 'production' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch Deploy Production DB
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --url "https://api.github.com/repos/${{ github.repository }}/actions/workflows/deploy-production.yml/dispatches" \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer $GITHUB_TOKEN" \
+            --data '{"ref":"production","inputs":{"checkout_ref":"${{ github.sha }}"}}'
+
+  dispatch_deploy_pr_preview:
+    needs: quality
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'preview-deploy') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch Deploy PR Preview
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --url "https://api.github.com/repos/${{ github.repository }}/actions/workflows/deploy-pr-preview.yml/dispatches" \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer $GITHUB_TOKEN" \
+            --data '{"ref":"main","inputs":{"checkout_ref":"${{ github.event.pull_request.head.sha }}","pr_number":"${{ github.event.pull_request.number }}","pr_head_sha":"${{ github.event.pull_request.head.sha }}"}}'

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,13 +1,20 @@
 name: Deploy PR Preview
 
 on:
-  pull_request_target:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
-      - unlabeled
+  workflow_dispatch:
+    inputs:
+      checkout_ref:
+        description: Git ref to checkout.
+        required: true
+        type: string
+      pr_number:
+        description: Pull request number.
+        required: true
+        type: string
+      pr_head_sha:
+        description: Pull request head SHA.
+        required: true
+        type: string
 
 permissions:
   actions: read
@@ -16,12 +23,11 @@ permissions:
   statuses: write
 
 concurrency:
-  group: deploy-pr-preview-${{ github.event.pull_request.number }}
+  group: deploy-pr-preview-${{ github.event.inputs.pr_number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   deploy_preview:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'preview-deploy') && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.ref == 'main' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: preview
@@ -43,7 +49,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.inputs.checkout_ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -110,15 +116,17 @@ jobs:
         uses: actions/github-script@v7
         env:
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment_url }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          PR_HEAD_SHA: ${{ github.event.inputs.pr_head_sha }}
         with:
           script: |
             const marker = '<!-- pr-preview-deploy -->';
-            const issue_number = context.payload.pull_request.number;
+            const issue_number = Number(process.env.PR_NUMBER);
             const body = `${marker}
             Preview deployment for label \`preview-deploy\`:
             ${process.env.DEPLOYMENT_URL}
 
-            Commit: \`${context.payload.pull_request.head.sha}\``;
+            Commit: \`${process.env.PR_HEAD_SHA}\``;
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,14 +1,12 @@
 name: Deploy Preview DB
 
 on:
-  workflow_run:
-    workflows:
-      - CI
-    types:
-      - completed
-    branches:
-      - main
   workflow_dispatch:
+    inputs:
+      checkout_ref:
+        description: Git ref to checkout.
+        required: false
+        type: string
 
 concurrency:
   group: deploy-preview
@@ -16,7 +14,6 @@ concurrency:
 
 jobs:
   deploy_db:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -28,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.inputs.checkout_ref || github.sha }}
 
       - name: Notify Vercel (deploy)
         uses: vercel/repository-dispatch/actions/status@v1
@@ -72,7 +69,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.inputs.checkout_ref || github.sha }}
 
       - name: Notify Vercel (preview bootstrap admin)
         uses: vercel/repository-dispatch/actions/status@v1

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,14 +1,12 @@
 name: Deploy Production DB
 
 on:
-  workflow_run:
-    workflows:
-      - CI
-    types:
-      - completed
-    branches:
-      - production
   workflow_dispatch:
+    inputs:
+      checkout_ref:
+        description: Git ref to checkout.
+        required: false
+        type: string
 
 concurrency:
   group: deploy-production
@@ -16,7 +14,6 @@ concurrency:
 
 jobs:
   deploy_db:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -28,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.inputs.checkout_ref || github.sha }}
 
       - name: Notify Vercel (deploy)
         uses: vercel/repository-dispatch/actions/status@v1
@@ -72,7 +69,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.inputs.checkout_ref || github.sha }}
 
       - name: Notify Vercel (production bootstrap admin)
         uses: vercel/repository-dispatch/actions/status@v1


### PR DESCRIPTION
## Scope summary
- Reworked deployment orchestration so deploy workflows remain separate GitHub Actions runs.
- CI now dispatches deploy workflows only after successful `quality`.
- Branch routing:
  - push `main` -> dispatch `deploy-preview.yml`
  - push `production` -> dispatch `deploy-production.yml`
  - PR to `main` with label `preview-deploy` (same repo) -> dispatch `deploy-pr-preview.yml`

## Test/verification results
- YAML parse check passed for:
  - `.github/workflows/ci.yml`
  - `.github/workflows/deploy-preview.yml`
  - `.github/workflows/deploy-production.yml`
  - `.github/workflows/deploy-pr-preview.yml`
- Full quality gates were not re-run in this change:
  - `yarn typecheck`
  - `yarn lint`
  - `yarn test:run`
  - `yarn build`

## Risk notes
- CI now requires `actions: write` to call workflow dispatch endpoints.
- Dispatch relies on GitHub API calls via `curl`; API/auth issues can block downstream deploy kickoff.
- Functional change scope is limited to trigger/orchestration behavior; deploy job internals are unchanged.
