### PR TITLE
fix(lists): scope character and campaign visibility by page context

### DIFF
--- a/src/app/api/campaigns/route.ts
+++ b/src/app/api/campaigns/route.ts
@@ -16,16 +16,24 @@ export async function GET(request: Request) {
   const { client, user } = auth.context;
   const url = new URL(request.url);
   const roleForUserId = url.searchParams.get("roleForUserId");
+  const scopeParam = url.searchParams.get("scope");
+  const scope =
+    scopeParam === "member" || scopeParam === "public" ? scopeParam : "all";
   const limitParam = Number(url.searchParams.get("limit") ?? "100");
   const limit = Number.isFinite(limitParam)
     ? Math.min(Math.max(limitParam, 1), 500)
     : 100;
 
-  const { data, error } = await client
+  let campaignsQuery = client
     .from("campaigns")
     .select("id, owner_user_id, title, description, is_private, created_at, updated_at")
-    .limit(limit)
-    .order("updated_at", { ascending: false });
+    .limit(limit);
+
+  if (scope === "public") {
+    campaignsQuery = campaignsQuery.eq("is_private", false);
+  }
+
+  const { data, error } = await campaignsQuery.order("updated_at", { ascending: false });
 
   if (error) {
     return jsonError(400, "campaign_list_failed", error.message);
@@ -84,8 +92,7 @@ export async function GET(request: Request) {
     (membershipsForTargetUser ?? []).map((membership) => membership.campaign_id),
   );
 
-  return jsonOk(
-    campaigns.map((campaign) => {
+  const enrichedCampaigns = campaigns.map((campaign) => {
       const acceptedMemberIds = acceptedMembersByCampaign.get(campaign.id) ?? [];
       const isOwner = campaign.owner_user_id === user.id;
       const isAcceptedPlayer =
@@ -108,8 +115,14 @@ export async function GET(request: Request) {
         current_user_role: isOwner ? "owner" : isAcceptedPlayer ? "player" : null,
         role_for_user: roleForTargetUser,
       };
-    }),
-  );
+    });
+
+  const visibleCampaigns =
+    scope === "member"
+      ? enrichedCampaigns.filter((campaign) => campaign.current_user_role !== null)
+      : enrichedCampaigns;
+
+  return jsonOk(visibleCampaigns);
 }
 
 export async function POST(request: Request) {

--- a/src/app/api/characters/route.ts
+++ b/src/app/api/characters/route.ts
@@ -18,18 +18,28 @@ export async function GET(request: Request) {
   }
 
   const url = new URL(request.url);
+  const scopeParam = url.searchParams.get("scope");
+  const scope =
+    scopeParam === "mine" || scopeParam === "public" ? scopeParam : "all";
   const limitParam = Number(url.searchParams.get("limit") ?? "100");
   const limit = Number.isFinite(limitParam)
     ? Math.min(Math.max(limitParam, 1), 500)
     : 100;
 
-  const { data, error } = await auth.context.client
+  let query = auth.context.client
     .from("characters")
     .select(
       "id, owner_user_id, campaign_id, type, name, age, description, avatar_path, is_private, created_at, updated_at",
     )
-    .limit(limit)
-    .order("updated_at", { ascending: false });
+    .limit(limit);
+
+  if (scope === "mine") {
+    query = query.eq("owner_user_id", auth.context.user.id);
+  } else if (scope === "public") {
+    query = query.eq("is_private", false);
+  }
+
+  const { data, error } = await query.order("updated_at", { ascending: false });
 
   if (error) {
     return jsonError(400, "character_list_failed", error.message);

--- a/src/features/campaigns/hooks/use-campaigns-query.ts
+++ b/src/features/campaigns/hooks/use-campaigns-query.ts
@@ -17,7 +17,7 @@ export function useCampaignsQuery(session: ClientSession | null) {
       }
 
       const [campaigns, me] = await Promise.all([
-        getCampaignsQuery(session),
+        getCampaignsQuery(session, { scope: "member" }),
         getMyUserQuery(session),
       ]);
 

--- a/src/features/campaigns/queries/get-campaigns.query.ts
+++ b/src/features/campaigns/queries/get-campaigns.query.ts
@@ -4,6 +4,7 @@ import type { Campaign } from "../types";
 
 type GetCampaignsQueryOptions = {
   roleForUserId?: string;
+  scope?: "member" | "public";
 };
 
 export async function getCampaignsQuery(
@@ -13,6 +14,9 @@ export async function getCampaignsQuery(
   const searchParams = new URLSearchParams();
   if (options?.roleForUserId) {
     searchParams.set("roleForUserId", options.roleForUserId);
+  }
+  if (options?.scope) {
+    searchParams.set("scope", options.scope);
   }
   const path = searchParams.size > 0 ? `/api/campaigns?${searchParams.toString()}` : "/api/campaigns";
 

--- a/src/features/campaigns/queries/tests/campaign-queries.test.ts
+++ b/src/features/campaigns/queries/tests/campaign-queries.test.ts
@@ -51,6 +51,16 @@ describe("campaign queries", () => {
     });
   });
 
+  it("getCampaignsQuery supports scope option", async () => {
+    const data = [{ id: "c3", owner_user_id: "u3", title: "C", description: "" }];
+    apiRequestMock.mockResolvedValueOnce({ data, error: null, status: 200 });
+
+    await expect(getCampaignsQuery(session, { scope: "member" })).resolves.toEqual(data);
+    expect(apiRequestMock).toHaveBeenCalledWith("/api/campaigns?scope=member", {
+      session,
+    });
+  });
+
   it("getCampaignsQuery throws on error response", async () => {
     apiRequestMock.mockResolvedValueOnce({
       data: null,

--- a/src/features/characters/hooks/use-characters-screen.ts
+++ b/src/features/characters/hooks/use-characters-screen.ts
@@ -20,7 +20,7 @@ export function useCharactersScreen(session: ClientSession | null) {
       if (!session) {
         throw new Error("Missing session");
       }
-      return getCharacters(session);
+      return getCharacters(session, { scope: "mine" });
     },
   });
 

--- a/src/features/characters/queries/characters-screen.query.ts
+++ b/src/features/characters/queries/characters-screen.query.ts
@@ -2,8 +2,21 @@ import { apiRequest, unwrapApiResponse } from "@/lib/client/api";
 import type { ClientSession } from "@/lib/client/session";
 import type { Character, CharacterCreateInput } from "../types";
 
-export async function getCharacters(session: ClientSession): Promise<Character[]> {
-  const response = await apiRequest<Character[]>("/api/characters", { session });
+type GetCharactersOptions = {
+  scope?: "mine" | "public";
+};
+
+export async function getCharacters(
+  session: ClientSession,
+  options?: GetCharactersOptions,
+): Promise<Character[]> {
+  const searchParams = new URLSearchParams();
+  if (options?.scope) {
+    searchParams.set("scope", options.scope);
+  }
+  const path = searchParams.size > 0 ? `/api/characters?${searchParams.toString()}` : "/api/characters";
+
+  const response = await apiRequest<Character[]>(path, { session });
   return unwrapApiResponse(response, "Failed to load characters");
 }
 

--- a/src/features/characters/queries/tests/character-queries.test.ts
+++ b/src/features/characters/queries/tests/character-queries.test.ts
@@ -46,6 +46,15 @@ describe("character queries", () => {
     expect(unwrapApiResponseMock).toHaveBeenCalledWith(response, "Failed to load characters");
   });
 
+  it("getCharacters supports scope option", async () => {
+    const response = { data: [{ id: "char1" }], error: null, status: 200 };
+    apiRequestMock.mockResolvedValueOnce(response);
+
+    await expect(getCharacters(session, { scope: "mine" })).resolves.toEqual([{ id: "char1" }]);
+    expect(apiRequestMock).toHaveBeenCalledWith("/api/characters?scope=mine", { session });
+    expect(unwrapApiResponseMock).toHaveBeenCalledWith(response, "Failed to load characters");
+  });
+
   it("createCharacter posts payload", async () => {
     const response = { data: { id: "char2" }, error: null, status: 201 };
     apiRequestMock.mockResolvedValueOnce(response);

--- a/src/page-modules/campaigns-page.tsx
+++ b/src/page-modules/campaigns-page.tsx
@@ -68,11 +68,7 @@ export function CampaignsPageView({ locale }: CampaignsPageViewProps) {
   const feedback = message || queryError;
   const campaigns = campaignsQuery.data?.campaigns ?? [];
   const currentUserId = campaignsQuery.data?.me.user.id;
-  const currentUserRole = campaignsQuery.data?.me.profile?.role;
-  const visibleCampaigns =
-    currentUserRole === "admin"
-      ? campaigns.filter((campaign) => campaign.owner_user_id === currentUserId)
-      : campaigns;
+  const visibleCampaigns = campaigns;
   const sortedAndFilteredCampaigns = sortCampaigns(
     searchCampaigns(visibleCampaigns, searchQuery),
     sortBy,

--- a/src/page-modules/characters-page.tsx
+++ b/src/page-modules/characters-page.tsx
@@ -90,16 +90,12 @@ export function CharactersPageView({ locale }: CharactersScreenProps) {
         throw new Error("Missing session");
       }
 
-      return getCampaignsQuery(session);
+      return getCampaignsQuery(session, { scope: "member" });
     },
   });
 
   const characters = charactersQuery.data ?? [];
-  const meUserId = meQuery.data?.user.id;
-  const visibleCharacters =
-    meQuery.data?.profile.role === "admin"
-      ? characters.filter((character) => character.owner_user_id === meUserId)
-      : characters;
+  const visibleCharacters = characters;
   const sortedAndFilteredCharacters = sortCharacters(
     searchCharacters(visibleCharacters, searchQuery),
     sortBy,

--- a/src/page-modules/home-page.tsx
+++ b/src/page-modules/home-page.tsx
@@ -103,8 +103,8 @@ export function HomePageView({
 
       const [me, campaigns, characters] = await Promise.all([
         getMe(session),
-        getCampaignsQuery(session),
-        getCharacters(session),
+        getCampaignsQuery(session, { scope: "public" }),
+        getCharacters(session, { scope: "public" }),
       ]);
 
       return {
@@ -199,8 +199,8 @@ export function HomePageView({
   const data = loggedInQuery.data;
   const me: MeResponse | null = data?.me ?? null;
   const currentUserId = me?.user.id;
-  const publicCampaigns = (data?.campaigns ?? []).filter((campaign) => !campaign.is_private);
-  const publicCharacters = (data?.characters ?? []).filter((character) => !character.is_private);
+  const publicCampaigns = data?.campaigns ?? [];
+  const publicCharacters = data?.characters ?? [];
   const campaignById = new Map(publicCampaigns.map((campaign) => [campaign.id, campaign]));
 
   const visibleCharactersByType = publicCharacters.filter(


### PR DESCRIPTION
## Scope summary
- adds server-side list scoping for /api/characters with scope=mine|public
- adds server-side list scoping for /api/campaigns with scope=member|public
- switches page data loading to intended scopes:
  - home: public campaigns/characters only
  - characters page: own characters + member campaigns
  - campaigns page: member campaigns only
- updates query helpers and tests for new scope params

## Test / verification results
- PASS: yarn test:run src/features/characters/queries/tests/character-queries.test.ts src/features/campaigns/queries/tests/campaign-queries.test.ts
- NOTE: yarn typecheck currently fails due to pre-existing generated .next/types/validator.ts module resolution errors for notifications routes/pages

## Risk notes
- low-to-medium risk around list visibility because endpoint filtering behavior changed
- mitigated by keeping default scope backward-compatible (all) and adding query-level tests for URL/param behavior
