### PR TITLE
fix(auth): prevent 500 during admin mfa setup

### DIFF
--- a/src/app/api/auth/mfa/totp/route.ts
+++ b/src/app/api/auth/mfa/totp/route.ts
@@ -29,6 +29,49 @@ function normalizeFriendlyName(value: unknown): string | undefined {
   return trimmed.slice(0, 64);
 }
 
+function isCompleteTotpEnrollment(data: unknown): data is {
+  id: string;
+  friendly_name?: string;
+  totp: { qr_code: string; secret: string; uri: string };
+} {
+  if (!data || typeof data !== "object") {
+    return false;
+  }
+
+  const candidate = data as {
+    id?: unknown;
+    totp?: { qr_code?: unknown; secret?: unknown; uri?: unknown } | null;
+  };
+
+  return (
+    typeof candidate.id === "string" &&
+    !!candidate.totp &&
+    typeof candidate.totp.qr_code === "string" &&
+    typeof candidate.totp.secret === "string" &&
+    typeof candidate.totp.uri === "string"
+  );
+}
+
+function isCompleteMfaVerification(data: unknown): data is {
+  access_token: string;
+  refresh_token?: string;
+} {
+  if (!data || typeof data !== "object") {
+    return false;
+  }
+
+  const candidate = data as { access_token?: unknown; refresh_token?: unknown };
+  if (typeof candidate.access_token !== "string") {
+    return false;
+  }
+
+  if (candidate.refresh_token !== undefined && typeof candidate.refresh_token !== "string") {
+    return false;
+  }
+
+  return true;
+}
+
 export async function GET(request: Request) {
   const auth = await requireAuth(request);
   if ("response" in auth) {
@@ -114,6 +157,10 @@ export async function POST(request: Request) {
     return jsonError(400, "mfa_enroll_failed", error.message);
   }
 
+  if (!isCompleteTotpEnrollment(data)) {
+    return jsonError(400, "mfa_enroll_failed", "MFA enrollment response was incomplete");
+  }
+
   return jsonOk({
     factorId: data.id,
     friendlyName: data.friendly_name ?? null,
@@ -173,6 +220,10 @@ export async function PATCH(request: Request) {
 
   if (error) {
     return jsonError(400, "mfa_verify_failed", error.message);
+  }
+
+  if (!isCompleteMfaVerification(data)) {
+    return jsonError(400, "mfa_verify_failed", "MFA verification response was incomplete");
   }
 
   return setSessionCookies(

--- a/src/app/api/auth/mfa/totp/tests/route.test.ts
+++ b/src/app/api/auth/mfa/totp/tests/route.test.ts
@@ -94,6 +94,36 @@ describe("auth mfa totp route", () => {
     });
   });
 
+  it("returns 400 when enrollment response is incomplete", async () => {
+    const enrollMock = vi.fn().mockResolvedValue({
+      data: null,
+      error: null,
+    });
+    requireAuthMock.mockResolvedValueOnce({
+      context: {
+        accessToken: "token",
+        user: { id: "u1" },
+        client: { auth: { mfa: { enroll: enrollMock } } },
+      },
+    });
+    getUserRoleMock.mockResolvedValueOnce({ role: "admin" });
+
+    const response = await POST(
+      new Request("http://localhost/api/auth/mfa/totp", {
+        method: "POST",
+        body: JSON.stringify({ friendlyName: "admin-factor" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "mfa_enroll_failed",
+        message: "MFA enrollment response was incomplete",
+      },
+    });
+  });
+
   it("rejects invalid verify code", async () => {
     requireAuthMock.mockResolvedValueOnce({
       context: {
@@ -116,6 +146,40 @@ describe("auth mfa totp route", () => {
       error: {
         code: "invalid_payload",
         message: "valid code is required",
+      },
+    });
+  });
+
+  it("returns 400 when verification response is incomplete", async () => {
+    const challengeMock = vi.fn().mockResolvedValue({
+      data: { id: "challenge-1" },
+      error: null,
+    });
+    const verifyMock = vi.fn().mockResolvedValue({
+      data: null,
+      error: null,
+    });
+    requireAuthMock.mockResolvedValueOnce({
+      context: {
+        accessToken: "token",
+        user: { id: "u1" },
+        client: { auth: { mfa: { challenge: challengeMock, verify: verifyMock } } },
+      },
+    });
+    getUserRoleMock.mockResolvedValueOnce({ role: "admin" });
+
+    const response = await PATCH(
+      new Request("http://localhost/api/auth/mfa/totp", {
+        method: "PATCH",
+        body: JSON.stringify({ factorId: "factor-1", code: "123456" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "mfa_verify_failed",
+        message: "MFA verification response was incomplete",
       },
     });
   });

--- a/src/server/auth/get-user-role.ts
+++ b/src/server/auth/get-user-role.ts
@@ -1,14 +1,18 @@
 import type { AuthContext } from "@/server/auth/require-auth";
+import { createServiceRoleSupabaseClient } from "@/server/supabase/service-role-client";
 
 export type AppUserRole = "admin" | "user" | null;
 
-export async function getUserRole(
-  context: Pick<AuthContext, "client" | "user">,
+type RoleLookupClient = Pick<AuthContext["client"], "from">;
+
+async function readUserRole(
+  client: RoleLookupClient,
+  userId: string,
 ): Promise<{ role: AppUserRole; errorMessage?: string }> {
-  const { data, error } = await context.client
+  const { data, error } = await client
     .from("profiles")
     .select("role")
-    .eq("id", context.user.id)
+    .eq("id", userId)
     .maybeSingle();
 
   if (error) {
@@ -20,4 +24,25 @@ export async function getUserRole(
   }
 
   return { role: null };
+}
+
+export async function getUserRole(
+  context: Pick<AuthContext, "client" | "user">,
+): Promise<{ role: AppUserRole; errorMessage?: string }> {
+  const profileRole = await readUserRole(context.client, context.user.id);
+  if (!profileRole.errorMessage) {
+    return profileRole;
+  }
+
+  try {
+    const serviceClient = createServiceRoleSupabaseClient();
+    const fallbackRole = await readUserRole(serviceClient, context.user.id);
+    if (!fallbackRole.errorMessage) {
+      return fallbackRole;
+    }
+  } catch {
+    // Fall through and return the original profile-query error.
+  }
+
+  return profileRole;
 }

--- a/src/server/auth/tests/get-user-role.test.ts
+++ b/src/server/auth/tests/get-user-role.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createServiceRoleSupabaseClientMock } = vi.hoisted(() => ({
+  createServiceRoleSupabaseClientMock: vi.fn(),
+}));
+
+vi.mock("@/server/supabase/service-role-client", () => ({
+  createServiceRoleSupabaseClient: createServiceRoleSupabaseClientMock,
+}));
+
+import { getUserRole } from "../get-user-role";
+
+function createRoleClient(result: { data: { role: string } | null; error: { message: string } | null }) {
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn().mockResolvedValue(result),
+        })),
+      })),
+    })),
+  };
+}
+
+describe("getUserRole", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns role from user-scoped profile query when available", async () => {
+    const userClient = createRoleClient({
+      data: { role: "admin" },
+      error: null,
+    });
+
+    const result = await getUserRole({
+      user: { id: "u1" } as never,
+      client: userClient as never,
+    });
+
+    expect(result).toEqual({ role: "admin" });
+    expect(createServiceRoleSupabaseClientMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to service role client when user-scoped role query errors", async () => {
+    const userClient = createRoleClient({
+      data: null,
+      error: { message: "permission denied for table profiles" },
+    });
+    const serviceClient = createRoleClient({
+      data: { role: "admin" },
+      error: null,
+    });
+    createServiceRoleSupabaseClientMock.mockReturnValueOnce(serviceClient);
+
+    const result = await getUserRole({
+      user: { id: "u1" } as never,
+      client: userClient as never,
+    });
+
+    expect(result).toEqual({ role: "admin" });
+    expect(createServiceRoleSupabaseClientMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns original error when fallback cannot be used", async () => {
+    const userClient = createRoleClient({
+      data: null,
+      error: { message: "relation \"profiles\" does not exist" },
+    });
+    createServiceRoleSupabaseClientMock.mockImplementationOnce(() => {
+      throw new Error("Missing environment variable: SUPABASE_SERVICE_ROLE_KEY");
+    });
+
+    const result = await getUserRole({
+      user: { id: "u1" } as never,
+      client: userClient as never,
+    });
+
+    expect(result).toEqual({
+      role: null,
+      errorMessage: "relation \"profiles\" does not exist",
+    });
+    expect(createServiceRoleSupabaseClientMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Scope summary
- make admin role lookup resilient by adding a service-role fallback when the user-scoped role read from profiles fails
- harden /api/auth/mfa/totp enroll and verify handlers against incomplete Supabase MFA payloads
- add focused tests for role fallback and incomplete MFA responses to prevent regressions

## Test/verification results
- yarn test:run src/server/auth/tests/require-admin.test.ts src/server/auth/tests/get-user-role.test.ts src/app/api/auth/mfa/totp/tests/route.test.ts passed
- yarn typecheck failed due to pre-existing issue in src/app/layout.tsx: Cannot find module @vercel/speed-insights/next

## Risk notes
- role fallback uses SUPABASE_SERVICE_ROLE_KEY; if missing, behavior falls back to previous error path
- no schema or migration changes; API behavior change is limited to replacing potential 500 responses with explicit 400 responses for malformed MFA provider responses