### PR TITLE
fix(auth): stabilize Turnstile loading and captcha mode env parsing

### DIFF
--- a/src/components/common/turnstile-widget.tsx
+++ b/src/components/common/turnstile-widget.tsx
@@ -39,7 +39,7 @@ export type TurnstileErrorReason =
   | "widget_error";
 
 let turnstileScriptPromise: Promise<void> | null = null;
-const TURNSTILE_SCRIPT_TIMEOUT_MS = 5_000;
+const TURNSTILE_SCRIPT_TIMEOUT_MS = 12_000;
 
 function mapTurnstileErrorReason(error: unknown): TurnstileErrorReason {
   if (!(error instanceof Error)) {
@@ -153,14 +153,24 @@ export function TurnstileWidget({
 }: TurnstileWidgetProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const widgetIdRef = useRef<string | null>(null);
+  const onTokenChangeRef = useRef(onTokenChange);
+  const onErrorReasonRef = useRef(onErrorReason);
   const [failedResetKey, setFailedResetKey] = useState<number | null>(null);
   const loadError = failedResetKey === resetKey;
 
   useEffect(() => {
+    onTokenChangeRef.current = onTokenChange;
+  }, [onTokenChange]);
+
+  useEffect(() => {
+    onErrorReasonRef.current = onErrorReason;
+  }, [onErrorReason]);
+
+  useEffect(() => {
     let cancelled = false;
 
-    onTokenChange(null);
-    onErrorReason?.(null);
+    onTokenChangeRef.current(null);
+    onErrorReasonRef.current?.(null);
     void ensureTurnstileScript()
       .then(() => {
         if (cancelled || !containerRef.current || !window.turnstile) {
@@ -171,26 +181,26 @@ export function TurnstileWidget({
           widgetIdRef.current = window.turnstile.render(containerRef.current, {
             sitekey: siteKey,
             callback: (token) => {
-              onErrorReason?.(null);
-              onTokenChange(token);
+              onErrorReasonRef.current?.(null);
+              onTokenChangeRef.current(token);
             },
-            "expired-callback": () => onTokenChange(null),
+            "expired-callback": () => onTokenChangeRef.current(null),
             "error-callback": () => {
-              onErrorReason?.("widget_error");
-              onTokenChange(null);
+              onErrorReasonRef.current?.("widget_error");
+              onTokenChangeRef.current(null);
             },
           });
         } catch {
           setFailedResetKey(resetKey);
-          onErrorReason?.("render_failed");
-          onTokenChange(null);
+          onErrorReasonRef.current?.("render_failed");
+          onTokenChangeRef.current(null);
         }
       })
       .catch((error) => {
         if (!cancelled) {
           setFailedResetKey(resetKey);
-          onErrorReason?.(mapTurnstileErrorReason(error));
-          onTokenChange(null);
+          onErrorReasonRef.current?.(mapTurnstileErrorReason(error));
+          onTokenChangeRef.current(null);
         }
       });
 
@@ -201,7 +211,7 @@ export function TurnstileWidget({
       }
       widgetIdRef.current = null;
     };
-  }, [siteKey, resetKey, onTokenChange, onErrorReason]);
+  }, [siteKey, resetKey]);
 
   if (loadError) {
     return loadErrorMessage ? (

--- a/src/lib/features/auth-captcha.ts
+++ b/src/lib/features/auth-captcha.ts
@@ -10,24 +10,48 @@ type AuthCaptchaClientConfig = {
 
 const KNOWN_CAPTCHA_MODES = new Set<AuthCaptchaMode>(["off", "optional", "required"]);
 
-function normalizeRuntimeEnvironment(value?: string | null): RuntimeEnvironment | null {
+function normalizeEnvValue(value?: string | null): string | null {
   if (!value) {
     return null;
   }
 
-  if (value === "development" || value === "preview" || value === "production") {
-    return value;
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const unquoted =
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+      ? trimmed.slice(1, -1).trim()
+      : trimmed;
+
+  return unquoted ? unquoted.toLowerCase() : null;
+}
+
+function normalizeRuntimeEnvironment(value?: string | null): RuntimeEnvironment | null {
+  const normalized = normalizeEnvValue(value);
+  if (!normalized) {
+    return null;
+  }
+
+  if (
+    normalized === "development" ||
+    normalized === "preview" ||
+    normalized === "production"
+  ) {
+    return normalized;
   }
 
   return null;
 }
 
 function normalizeCaptchaMode(value?: string | null): AuthCaptchaMode | null {
-  if (!value) {
+  const normalized = normalizeEnvValue(value);
+  if (!normalized) {
     return null;
   }
 
-  const normalized = value.trim().toLowerCase();
   if (KNOWN_CAPTCHA_MODES.has(normalized as AuthCaptchaMode)) {
     return normalized as AuthCaptchaMode;
   }

--- a/src/lib/features/tests/auth-captcha.test.ts
+++ b/src/lib/features/tests/auth-captcha.test.ts
@@ -32,6 +32,11 @@ describe("auth captcha client config", () => {
     expect(resolveClientAuthCaptchaMode()).toBe("required");
   });
 
+  it("accepts quoted explicit mode override", () => {
+    process.env.NEXT_PUBLIC_AUTH_CAPTCHA_MODE = "'off'";
+    expect(resolveClientAuthCaptchaMode()).toBe("off");
+  });
+
   it("trims and returns site key", () => {
     process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY = "  site-key  ";
     expect(getTurnstileSiteKey()).toBe("site-key");

--- a/src/server/auth/auth-hardening.ts
+++ b/src/server/auth/auth-hardening.ts
@@ -4,12 +4,31 @@ export type AuthCaptchaMode = "off" | "optional" | "required";
 
 const KNOWN_CAPTCHA_MODES = new Set<AuthCaptchaMode>(["off", "optional", "required"]);
 
-function parseBooleanEnv(value?: string): boolean | null {
+function normalizeEnvValue(value?: string): string | null {
   if (!value) {
     return null;
   }
 
-  const normalized = value.trim().toLowerCase();
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const unquoted =
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+      ? trimmed.slice(1, -1).trim()
+      : trimmed;
+
+  return unquoted ? unquoted.toLowerCase() : null;
+}
+
+function parseBooleanEnv(value?: string): boolean | null {
+  const normalized = normalizeEnvValue(value);
+  if (!normalized) {
+    return null;
+  }
+
   if (normalized === "true") {
     return true;
   }
@@ -45,7 +64,7 @@ export function isAdminMfaRequired(): boolean {
 }
 
 export function resolveAuthCaptchaMode(): AuthCaptchaMode {
-  const rawMode = process.env.AUTH_CAPTCHA_MODE?.trim().toLowerCase();
+  const rawMode = normalizeEnvValue(process.env.AUTH_CAPTCHA_MODE);
   if (rawMode && KNOWN_CAPTCHA_MODES.has(rawMode as AuthCaptchaMode)) {
     return rawMode as AuthCaptchaMode;
   }

--- a/src/server/auth/tests/auth-hardening.test.ts
+++ b/src/server/auth/tests/auth-hardening.test.ts
@@ -54,6 +54,11 @@ describe("auth hardening", () => {
     expect(resolveAuthCaptchaMode()).toBe("required");
   });
 
+  it("accepts quoted auth captcha mode", () => {
+    process.env.AUTH_CAPTCHA_MODE = '"off"';
+    expect(resolveAuthCaptchaMode()).toBe("off");
+  });
+
   it("detects aal2 from access token claim", () => {
     const token = buildJwt({ aal: "aal2" });
     expect(hasAal2AuthLevel(token)).toBe(true);


### PR DESCRIPTION
## Scope summary
- stabilize Turnstile widget lifecycle so callback prop identity changes do not force widget teardown/re-render loops
- increase Turnstile script load timeout from 5s to 12s to reduce false-negative load failures on slower networks
- harden auth captcha env parsing on server/client by accepting quoted values (e.g. "off", 'off')
- add unit coverage for quoted captcha mode values

## Test/verification results
- `yarn test:run src/server/auth/tests/auth-hardening.test.ts` ✅
- `yarn test:run src/lib/features/tests/auth-captcha.test.ts` ✅
- `yarn typecheck` ✅
- `yarn lint` ✅
- `yarn build` ✅

## Risk notes
- low risk: changes are limited to captcha config parsing and widget init lifecycle
- no API contract changes
- remaining operational risk: NEXT_PUBLIC env updates still require a fresh Vercel build/deploy to take effect
