### PR TITLE
fix(storage): use authenticated client for signed image routes

### DIFF
--- a/src/app/api/storage/character-images/signed-upload/route.ts
+++ b/src/app/api/storage/character-images/signed-upload/route.ts
@@ -75,7 +75,7 @@ export async function POST(request: Request) {
   }
 
   const path = `${auth.context.user.id}/${body.characterId}/${randomUUID()}-${sanitizeFileName(body.fileName)}`;
-  const { data, error } = await auth.context.client.storage
+  const { data, error } = await auth.context.authClient.storage
     .from("character-images")
     .createSignedUploadUrl(path);
 

--- a/src/app/api/storage/character-images/signed-upload/tests/route.test.ts
+++ b/src/app/api/storage/character-images/signed-upload/tests/route.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { enforceRateLimitMock, getUserRoleMock, requireAuthMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  enforceRateLimitMock: vi.fn(),
+  getUserRoleMock: vi.fn(),
+}));
+
+vi.mock("@/server/auth/require-auth", () => ({
+  requireAuth: requireAuthMock,
+}));
+
+vi.mock("@/server/rate-limit/enforce-rate-limit", () => ({
+  enforceRateLimit: enforceRateLimitMock,
+}));
+
+vi.mock("@/server/auth/get-user-role", () => ({
+  getUserRole: getUserRoleMock,
+}));
+
+import { POST } from "../route";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("character image signed upload route", () => {
+  it("uses the authenticated storage client for signed upload URLs", async () => {
+    const maybeSingleMock = vi.fn().mockResolvedValue({
+      data: { owner_user_id: "user-1", is_private: false },
+      error: null,
+    });
+    const eqMock = vi.fn(() => ({ maybeSingle: maybeSingleMock }));
+    const selectMock = vi.fn(() => ({ eq: eqMock }));
+    const dataClientFromMock = vi.fn(() => ({ select: selectMock }));
+
+    const createSignedUploadUrlWithDataClientMock = vi.fn();
+    const dataClientStorageFromMock = vi.fn(() => ({
+      createSignedUploadUrl: createSignedUploadUrlWithDataClientMock,
+    }));
+
+    const createSignedUploadUrlWithAuthClientMock = vi.fn().mockResolvedValue({
+      data: { path: "user-1/character-1/path.png", token: "token" },
+      error: null,
+    });
+    const authClientStorageFromMock = vi.fn(() => ({
+      createSignedUploadUrl: createSignedUploadUrlWithAuthClientMock,
+    }));
+
+    requireAuthMock.mockResolvedValueOnce({
+      context: {
+        user: { id: "user-1" },
+        client: {
+          from: dataClientFromMock,
+          storage: {
+            from: dataClientStorageFromMock,
+          },
+        },
+        authClient: {
+          storage: {
+            from: authClientStorageFromMock,
+          },
+        },
+      },
+    });
+    enforceRateLimitMock.mockResolvedValueOnce(null);
+    getUserRoleMock.mockResolvedValueOnce({ role: "user" });
+
+    const response = await POST(
+      new Request("http://localhost/api/storage/character-images/signed-upload", {
+        method: "POST",
+        body: JSON.stringify({
+          characterId: "character-1",
+          fileName: "Avatar.PNG",
+          width: 256,
+          height: 256,
+          fileSize: 1024,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(dataClientFromMock).toHaveBeenCalledWith("characters");
+    expect(authClientStorageFromMock).toHaveBeenCalledWith("character-images");
+    expect(createSignedUploadUrlWithAuthClientMock).toHaveBeenCalledTimes(1);
+    expect(createSignedUploadUrlWithDataClientMock).not.toHaveBeenCalled();
+    expect(dataClientStorageFromMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/storage/character-images/signed-url/route.ts
+++ b/src/app/api/storage/character-images/signed-url/route.ts
@@ -17,7 +17,7 @@ export async function POST(request: Request) {
     return jsonError(400, "invalid_payload", "path is required");
   }
 
-  const { data, error } = await auth.context.client.storage
+  const { data, error } = await auth.context.authClient.storage
     .from("character-images")
     .createSignedUrl(body.path, body.expiresIn ?? 60 * 10);
 

--- a/src/app/api/storage/character-images/signed-url/tests/route.test.ts
+++ b/src/app/api/storage/character-images/signed-url/tests/route.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { requireAuthMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+}));
+
+vi.mock("@/server/auth/require-auth", () => ({
+  requireAuth: requireAuthMock,
+}));
+
+import { POST } from "../route";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("character image signed url route", () => {
+  it("uses the authenticated storage client for signed URLs", async () => {
+    const createSignedUrlWithAuthClientMock = vi.fn().mockResolvedValue({
+      data: { signedUrl: "https://example.test/signed" },
+      error: null,
+    });
+    const authClientStorageFromMock = vi.fn(() => ({
+      createSignedUrl: createSignedUrlWithAuthClientMock,
+    }));
+
+    const createSignedUrlWithDataClientMock = vi.fn();
+    const dataClientStorageFromMock = vi.fn(() => ({
+      createSignedUrl: createSignedUrlWithDataClientMock,
+    }));
+
+    requireAuthMock.mockResolvedValueOnce({
+      context: {
+        client: {
+          storage: {
+            from: dataClientStorageFromMock,
+          },
+        },
+        authClient: {
+          storage: {
+            from: authClientStorageFromMock,
+          },
+        },
+      },
+    });
+
+    const response = await POST(
+      new Request("http://localhost/api/storage/character-images/signed-url", {
+        method: "POST",
+        body: JSON.stringify({
+          path: "user-1/character-1/avatar.png",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(authClientStorageFromMock).toHaveBeenCalledWith("character-images");
+    expect(createSignedUrlWithAuthClientMock).toHaveBeenCalledWith(
+      "user-1/character-1/avatar.png",
+      600,
+    );
+    expect(createSignedUrlWithDataClientMock).not.toHaveBeenCalled();
+    expect(dataClientStorageFromMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/storage/profile-images/signed-upload/route.ts
+++ b/src/app/api/storage/profile-images/signed-upload/route.ts
@@ -43,7 +43,7 @@ export async function POST(request: Request) {
   }
 
   const path = `${auth.context.user.id}/${randomUUID()}-${sanitizeFileName(body.fileName)}`;
-  const { data, error } = await auth.context.client.storage
+  const { data, error } = await auth.context.authClient.storage
     .from("profile-images")
     .createSignedUploadUrl(path);
 

--- a/src/app/api/storage/profile-images/signed-upload/tests/route.test.ts
+++ b/src/app/api/storage/profile-images/signed-upload/tests/route.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { enforceRateLimitMock, requireAuthMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  enforceRateLimitMock: vi.fn(),
+}));
+
+vi.mock("@/server/auth/require-auth", () => ({
+  requireAuth: requireAuthMock,
+}));
+
+vi.mock("@/server/rate-limit/enforce-rate-limit", () => ({
+  enforceRateLimit: enforceRateLimitMock,
+}));
+
+import { POST } from "../route";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("profile image signed upload route", () => {
+  it("uses the authenticated storage client for signed upload URLs", async () => {
+    const createSignedUploadUrlWithAuthClientMock = vi.fn().mockResolvedValue({
+      data: { path: "user-1/path.png", token: "token" },
+      error: null,
+    });
+    const authClientStorageFromMock = vi.fn(() => ({
+      createSignedUploadUrl: createSignedUploadUrlWithAuthClientMock,
+    }));
+
+    const createSignedUploadUrlWithDataClientMock = vi.fn();
+    const dataClientStorageFromMock = vi.fn(() => ({
+      createSignedUploadUrl: createSignedUploadUrlWithDataClientMock,
+    }));
+
+    requireAuthMock.mockResolvedValueOnce({
+      context: {
+        user: { id: "user-1" },
+        client: {
+          storage: {
+            from: dataClientStorageFromMock,
+          },
+        },
+        authClient: {
+          storage: {
+            from: authClientStorageFromMock,
+          },
+        },
+      },
+    });
+    enforceRateLimitMock.mockResolvedValueOnce(null);
+
+    const response = await POST(
+      new Request("http://localhost/api/storage/profile-images/signed-upload", {
+        method: "POST",
+        body: JSON.stringify({
+          fileName: "Avatar.PNG",
+          width: 256,
+          height: 256,
+          fileSize: 1024,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(authClientStorageFromMock).toHaveBeenCalledWith("profile-images");
+    expect(createSignedUploadUrlWithAuthClientMock).toHaveBeenCalledTimes(1);
+    expect(createSignedUploadUrlWithDataClientMock).not.toHaveBeenCalled();
+    expect(dataClientStorageFromMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/storage/profile-images/signed-url/route.ts
+++ b/src/app/api/storage/profile-images/signed-url/route.ts
@@ -17,7 +17,7 @@ export async function POST(request: Request) {
     return jsonError(400, "invalid_payload", "path is required");
   }
 
-  const { data, error } = await auth.context.client.storage
+  const { data, error } = await auth.context.authClient.storage
     .from("profile-images")
     .createSignedUrl(body.path, body.expiresIn ?? 60 * 10);
 

--- a/src/app/api/storage/profile-images/signed-url/tests/route.test.ts
+++ b/src/app/api/storage/profile-images/signed-url/tests/route.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { requireAuthMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+}));
+
+vi.mock("@/server/auth/require-auth", () => ({
+  requireAuth: requireAuthMock,
+}));
+
+import { POST } from "../route";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("profile image signed url route", () => {
+  it("uses the authenticated storage client for signed URLs", async () => {
+    const createSignedUrlWithAuthClientMock = vi.fn().mockResolvedValue({
+      data: { signedUrl: "https://example.test/signed" },
+      error: null,
+    });
+    const authClientStorageFromMock = vi.fn(() => ({
+      createSignedUrl: createSignedUrlWithAuthClientMock,
+    }));
+
+    const createSignedUrlWithDataClientMock = vi.fn();
+    const dataClientStorageFromMock = vi.fn(() => ({
+      createSignedUrl: createSignedUrlWithDataClientMock,
+    }));
+
+    requireAuthMock.mockResolvedValueOnce({
+      context: {
+        client: {
+          storage: {
+            from: dataClientStorageFromMock,
+          },
+        },
+        authClient: {
+          storage: {
+            from: authClientStorageFromMock,
+          },
+        },
+      },
+    });
+
+    const response = await POST(
+      new Request("http://localhost/api/storage/profile-images/signed-url", {
+        method: "POST",
+        body: JSON.stringify({
+          path: "user-1/avatar.png",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(authClientStorageFromMock).toHaveBeenCalledWith("profile-images");
+    expect(createSignedUrlWithAuthClientMock).toHaveBeenCalledWith("user-1/avatar.png", 600);
+    expect(createSignedUrlWithDataClientMock).not.toHaveBeenCalled();
+    expect(dataClientStorageFromMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Scope summary
- switch all storage route handlers from  to 
- affected endpoints:
  - 
  - 
  - 
  - 
- add route-level regression tests for each endpoint to ensure authenticated storage client usage

## Test/verification results
- yarn run v1.22.22
$ vitest run

 RUN  v4.0.18 /Users/laura/dev/pnp-app

 ✓ src/page-modules/tests/auth-session-from-url.test.ts (4 tests) 3ms
 ✓ src/features/campaigns/logic/tests/campaign-list.logic.test.ts (3 tests) 7ms
 ✓ src/features/characters/queries/tests/character-queries.test.ts (18 tests) 5ms
 ✓ src/server/auth/tests/require-auth.test.ts (5 tests) 7ms
 ✓ src/features/users/queries/tests/users-queries.test.ts (20 tests) 13ms
 ✓ src/app/api/admin/users/[userId]/tests/route.test.ts (5 tests) 9ms
 ✓ src/app/api/admin/users/tests/route.test.ts (6 tests) 13ms
 ✓ src/server/auth/tests/require-admin.test.ts (5 tests) 5ms
 ✓ src/lib/client/tests/api.test.ts (9 tests) 9ms
 ✓ src/lib/api/tests/http.test.ts (4 tests) 4ms
 ✓ src/app/api/storage/profile-images/signed-upload/tests/route.test.ts (1 test) 4ms
 ✓ src/app/api/auth/mfa/totp/tests/route.test.ts (5 tests) 8ms
 ✓ src/app/api/admin/characters/[characterId]/tests/route.test.ts (2 tests) 9ms
 ✓ src/features/campaigns/queries/tests/campaign-queries.test.ts (15 tests) 6ms
 ✓ src/app/api/admin/campaigns/tests/route.test.ts (2 tests) 3ms
 ✓ src/app/api/storage/character-images/signed-url/tests/route.test.ts (1 test) 5ms
 ✓ src/app/tests/page.test.tsx (2 tests) 272ms
 ✓ src/features/characters/logic/tests/character-list.logic.test.ts (4 tests) 10ms
 ✓ src/app/api/admin/campaigns/[campaignId]/tests/route.test.ts (2 tests) 4ms
 ✓ src/app/api/storage/profile-images/signed-url/tests/route.test.ts (1 test) 5ms
 ✓ src/app/api/admin/characters/tests/route.test.ts (2 tests) 8ms
 ✓ src/app/api/storage/character-images/signed-upload/tests/route.test.ts (1 test) 5ms
 ✓ src/lib/api/tests/auth-validation.test.ts (12 tests) 4ms
 ✓ src/app/api/auth/register/tests/route.test.ts (7 tests) 7ms
 ✓ src/server/auth/tests/get-user-role.test.ts (3 tests) 4ms
 ✓ src/features/notifications/queries/tests/notifications-queries.test.ts (6 tests) 7ms
 ✓ src/lib/features/tests/auth-captcha.test.ts (7 tests) 2ms
 ✓ src/features/notifications/logic/tests/notification-list.logic.test.ts (5 tests) 4ms
 ✓ src/lib/client/tests/session.test.ts (6 tests) 7ms
 ✓ src/lib/i18n/tests/i18n.test.ts (3 tests) 3ms
 ✓ src/lib/features/tests/feature-flags.test.ts (11 tests) 2ms
 ✓ src/lib/utils/tests/list.test.ts (2 tests) 3ms
 ✓ src/lib/logic/tests/collections.test.ts (3 tests) 1ms
 ✓ src/lib/features/tests/performance-observability.test.ts (7 tests) 3ms
 ✓ src/server/auth/tests/auth-hardening.test.ts (9 tests) 2ms
 ✓ src/lib/storage/tests/files.test.ts (2 tests) 1ms
 ✓ src/features/users/logic/tests/role.logic.test.ts (3 tests) 1ms
 ✓ src/features/campaigns/logic/tests/campaign-role.logic.test.ts (3 tests) 1ms

 Test Files  38 passed (38)
      Tests  206 passed (206)
   Start at  19:06:18
   Duration  2.93s (transform 1.19s, setup 4.42s, import 2.22s, tests 463ms, environment 13.85s)

Done in 3.73s. ✅
- yarn run v1.22.22
$ tsc --noEmit
Done in 1.88s. ✅
- yarn run v1.22.22
$ eslint
Done in 3.30s. ✅
- yarn run v1.22.22
$ next build
▲ Next.js 16.1.6 (Turbopack)
- Environments: .env.local

  Creating an optimized production build ...
✓ Compiled successfully in 1973.5ms
  Running TypeScript ...
  Collecting page data using 9 workers ...
  Generating static pages using 9 workers (0/49) ...
  Generating static pages using 9 workers (12/49) 
  Generating static pages using 9 workers (24/49) 
  Generating static pages using 9 workers (36/49) 
✓ Generating static pages using 9 workers (49/49) in 111.8ms
  Finalizing page optimization ...

Route (app)
┌ ƒ /
├ ƒ /_not-found
├ ƒ /.well-known/vercel/flags
├ ƒ /admin
├ ƒ /admin/campaigns
├ ƒ /admin/characters
├ ƒ /admin/users
├ ƒ /api/admin/bootstrap
├ ƒ /api/admin/campaigns
├ ƒ /api/admin/campaigns/[campaignId]
├ ƒ /api/admin/characters
├ ƒ /api/admin/characters/[characterId]
├ ƒ /api/admin/users
├ ƒ /api/admin/users/[userId]
├ ƒ /api/auth/callback/exchange
├ ƒ /api/auth/callback/verify
├ ƒ /api/auth/email/resend-verification
├ ƒ /api/auth/login
├ ƒ /api/auth/logout
├ ƒ /api/auth/mfa/totp
├ ƒ /api/auth/password-reset/confirm
├ ƒ /api/auth/password-reset/request
├ ƒ /api/auth/register
├ ƒ /api/campaigns
├ ƒ /api/campaigns/[campaignId]
├ ƒ /api/campaigns/[campaignId]/invitations
├ ƒ /api/campaigns/[campaignId]/join-requests
├ ƒ /api/campaigns/[campaignId]/memberships/[membershipId]/decision
├ ƒ /api/characters
├ ƒ /api/characters/[characterId]
├ ƒ /api/characters/[characterId]/assign-campaign
├ ƒ /api/characters/[characterId]/outgoing-relationships
├ ƒ /api/characters/[characterId]/relations-summary
├ ƒ /api/characters/[characterId]/relations/[otherCharacterId]
├ ƒ /api/characters/[characterId]/unassign-campaign
├ ƒ /api/me
├ ƒ /api/me/profile
├ ƒ /api/me/settings/email
├ ƒ /api/me/settings/password
├ ƒ /api/notifications
├ ƒ /api/notifications/[notificationId]/read
├ ƒ /api/notifications/read-all
├ ƒ /api/notifications/unread-count
├ ƒ /api/relationships
├ ƒ /api/relationships/[relationshipId]
├ ƒ /api/relationships/[relationshipId]/timeline
├ ƒ /api/relationships/catalogs
├ ƒ /api/storage/character-images/signed-upload
├ ƒ /api/storage/character-images/signed-url
├ ƒ /api/storage/profile-images/signed-upload
├ ƒ /api/storage/profile-images/signed-url
├ ƒ /api/users
├ ƒ /api/users/[userId]
├ ƒ /auth
├ ƒ /auth/callback
├ ƒ /auth/reset-password
├ ƒ /campaigns
├ ƒ /campaigns/[campaignId]
├ ƒ /characters
├ ƒ /characters/[characterId]
├ ƒ /characters/[characterId]/edit
├ ƒ /dashboard
├ ƒ /notifications
├ ƒ /password-reset
├ ƒ /profile
├ ƒ /register
├ ƒ /settings
└ ƒ /users/[userId]


ƒ Proxy (Middleware)

ƒ  (Dynamic)  server-rendered on demand

Done in 5.47s. ✅

## Risk notes
- low risk, narrow change in storage route auth client selection only
- no schema or RLS policy migration changes
- test coverage added to guard against regressions in storage client usage