### PR TITLE
fix(orchestrator): support codex approval flag syntax

### DIFF
--- a/docs/development/ai-agent-quickstart.md
+++ b/docs/development/ai-agent-quickstart.md
@@ -80,9 +80,9 @@ When you do not want full routing, call one skill explicitly in the prompt.
 - Orchestrator skill only:
   - `codex --sandbox workspace-write -a untrusted "Use pnp-orchestrator as primary skill. Task: <your task>"`
 - PR review skill only:
-  - `codex exec --sandbox workspace-write --ask-for-approval untrusted "Use pnp-pr-review as primary skill. Review PR 48 and output findings by severity."`
+  - `codex -a untrusted exec --sandbox workspace-write "Use pnp-pr-review as primary skill. Review PR 48 and output findings by severity."`
 - Docs maintainer skill only:
-  - `codex exec --sandbox workspace-write --ask-for-approval untrusted "Use pnp-docs-maintainer as primary skill. Clean up docs links and remove duplication."`
+  - `codex -a untrusted exec --sandbox workspace-write "Use pnp-docs-maintainer as primary skill. Clean up docs links and remove duplication."`
 
 Skill definitions and responsibilities:
 

--- a/scripts/multi-agent-orchestrator/auto.mjs
+++ b/scripts/multi-agent-orchestrator/auto.mjs
@@ -399,9 +399,10 @@ function buildCodexExecCommand(prompt, outputFile, args) {
   const safePrompt = buildSafeAgentPrompt(prompt);
 
   return [
-    "codex exec",
+    "codex",
+    `-a ${args.approvalPolicy}`,
+    "exec",
     "--sandbox workspace-write",
-    `--ask-for-approval ${args.approvalPolicy}`,
     `--output-last-message ${shellQuote(outputFile)}`,
     shellQuote(safePrompt),
   ].join(" ");


### PR DESCRIPTION
## Summary\n- fix orchestrator auto command builder to use Codex CLI approval flag syntax compatible with current CLI versions\n- change generated commands from `codex exec ... --ask-for-approval ...` to `codex -a <policy> exec ...`\n- update quickstart examples to the same command form\n\n## Verification\n- yarn lint scripts/multi-agent-orchestrator/auto.mjs\n- yarn orchestrator:auto --prompt "Wir haben jetzt einige änderunge ngemacht. gehe alle issue durch, überprüfe ob sie noch notwendig sind und update sie wenn nötig. gehe auch den bestehenden e2e regression PR durch" --dry-run\n\n## Risk Notes\n- low risk: only command-string assembly and docs changed\n- no runtime product code paths changed\n