### PR TITLE
chore(orchestrator): enforce mandatory skill disclosure

### DIFF
--- a/skills/pnp-orchestrator/SKILL.md
+++ b/skills/pnp-orchestrator/SKILL.md
@@ -34,6 +34,13 @@ Preferred entrypoints:
    - risks and rollback
 5. Ensure branch/PR constraints from `AGENTS.md` remain satisfied.
 
+## Skill Disclosure (Mandatory)
+
+1. At the start of every new user task, explicitly state the primary skill being used.
+2. Explicitly list any routed subskills and the one-line reason for the chosen order.
+3. If no subskills are used, explicitly state that no subskill routing is required.
+4. Keep this disclosure concise (one short line) and place it before substantive execution updates.
+
 ## Enforce Completion Standard
 
 1. Do not stop at planning unless asked.


### PR DESCRIPTION
## Summary

- add a mandatory `Skill Disclosure` section to `skills/pnp-orchestrator/SKILL.md`
- require explicit declaration of primary skill + routed subskills at the start of each new user task
- keep disclosure concise and placed before substantive execution updates

## Linked Issue(s)

- No linked issue

## Flow Impact

- [x] No user-flow impact
- [ ] Existing flow changed
- [ ] New flow added

## Impact Signals (Regression Auto-Label)

- [ ] Security impact
- [ ] Data model impact
- [ ] Performance impact

## E2E Coverage Matrix

| AC / User Flow Ref | Scenario ID | Test status | Why E2E vs feature test |
| ------------------ | ----------- | ----------- | ----------------------- |
| N/A                | N/A         | N/A         | Docs/skill instruction only |

## PR Acceptance Criteria (Required When No Linked Issue)

- Orchestrator skill instructions explicitly require skill disclosure for each new task.
- Disclosure requirements are concrete (primary skill, subskills/order rationale, concise placement).

## PR Happy Paths (Required When No Linked Issue)

- Starting a new task with orchestrator now follows the disclosure section before execution updates.

## Scope

- [x] One coherent change package
- [x] Branch created from latest `main`

## Verification

- [ ] `yarn typecheck`
- [ ] `yarn lint`
- [ ] `yarn test:run`
- [ ] `yarn build` (required for release-impacting changes)
- [ ] `yarn test:e2e --grep @smoke` (for flow-impacting changes)

Notes:
- Not run (docs/skill-instructions only; no product/runtime code changed).

## Documentation

- [x] Relevant docs updated when conventions/behavior changed
- [x] ADR linked or rationale given when architecture/security/runtime boundaries changed

Rationale:
- This updates repository-local agent workflow instructions only.

## Risk and Rollback

- Risk notes:
  - Low risk; potential only for stricter agent output format expectations.
- Rollback approach:
  - Revert commit `c090046`.

## Agent Automation Safety (when applicable)

- [x] No sandbox/approval bypass flags used
- [x] High-risk or destructive overrides (`--confirm-risky`, `--allow-destructive`) documented with rationale
