### PR TITLE
fix(ci): keep preview label gate compatible with push pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ concurrency:
 
 jobs:
   preview_label_gate:
-    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     outputs:
       required_checks_ready: ${{ steps.evaluate.outputs.required_checks_ready }}


### PR DESCRIPTION
## Summary
- apply the same CI hotfix to main that was merged to production in #65
- ensure preview_label_gate is not PR-only so push pipelines continue to run

## Why
Without this sync, main and production CI definitions diverge and future main -> production merges can reintroduce workflow drift.

## Verification
- production CI run 22200714289 completed with expected chain
- Deploy Production DB run 22200839223 succeeded
