### PR TITLE
feat(users): add avatars overview page

### DIFF
--- a/scripts/pr-screenshot-targets.config.mjs
+++ b/scripts/pr-screenshot-targets.config.mjs
@@ -48,6 +48,12 @@ export const KNOWN_TARGETS = [
     fileName: "09-settings.png",
     requiresAuth: true,
   },
+  {
+    id: "users-avatars",
+    route: "/users/avatars",
+    fileName: "10-users-avatars.png",
+    requiresAuth: true,
+  },
 ];
 
 export const KNOWN_TARGET_IDS = new Set(
@@ -161,6 +167,15 @@ export const TARGET_RULES = [
       /^src\/page-modules\/settings-page\.tsx$/,
       /^src\/features\/users\/queries\/users-settings\.query\.ts$/,
       /^src\/app\/api\/me\/settings\//,
+    ],
+  },
+  {
+    targetId: "users-avatars",
+    patterns: [
+      /^src\/app\/users\/avatars\/page\.tsx$/,
+      /^src\/page-modules\/users-avatars-page\.tsx$/,
+      /^src\/app\/api\/users\/avatars\//,
+      /^src\/features\/users\/queries\/users-avatar-list\.query\.ts$/,
     ],
   },
 ];

--- a/src/app/api/users/avatars/route.ts
+++ b/src/app/api/users/avatars/route.ts
@@ -1,0 +1,77 @@
+import { jsonError, jsonOk } from "@/lib/api/http";
+import { requireAuth } from "@/server/auth/require-auth";
+
+type ProfileAvatarRow = {
+  id: string;
+  username: string;
+  avatar_path: string | null;
+  role: "user" | "admin" | null;
+};
+
+type SignedUrlRow = {
+  path: string;
+  signedUrl?: string;
+};
+
+export async function GET(request: Request) {
+  const auth = await requireAuth(request);
+  if ("response" in auth) {
+    return auth.response;
+  }
+
+  const url = new URL(request.url);
+  const limitParam = Number(url.searchParams.get("limit") ?? "200");
+  const limit = Number.isFinite(limitParam)
+    ? Math.min(Math.max(limitParam, 1), 1000)
+    : 200;
+
+  const { data, error } = await auth.context.client
+    .from("profiles")
+    .select("id, username, avatar_path, role")
+    .limit(limit)
+    .order("username", { ascending: true });
+
+  if (error) {
+    return jsonError(400, "users_avatar_list_failed", error.message);
+  }
+
+  const profiles = ((data ?? []) as ProfileAvatarRow[]).filter(
+    (profile) => profile.role !== "admin",
+  );
+  const avatarPaths = profiles.flatMap((profile) =>
+    profile.avatar_path ? [profile.avatar_path] : [],
+  );
+
+  const signedUrlByPath = new Map<string, string>();
+  if (avatarPaths.length > 0) {
+    const { data: signedUrls, error: signedUrlsError } =
+      await auth.context.authClient.storage
+        .from("profile-images")
+        .createSignedUrls(avatarPaths, 60 * 10);
+
+    if (signedUrlsError) {
+      return jsonError(
+        400,
+        "profile_image_signed_urls_failed",
+        signedUrlsError.message,
+      );
+    }
+
+    for (const entry of (signedUrls ?? []) as SignedUrlRow[]) {
+      if (entry.path && typeof entry.signedUrl === "string") {
+        signedUrlByPath.set(entry.path, entry.signedUrl);
+      }
+    }
+  }
+
+  return jsonOk(
+    profiles.map((profile) => ({
+      id: profile.id,
+      username: profile.username,
+      avatarPath: profile.avatar_path,
+      avatarUrl: profile.avatar_path
+        ? (signedUrlByPath.get(profile.avatar_path) ?? null)
+        : null,
+    })),
+  );
+}

--- a/src/app/api/users/avatars/tests/route.test.ts
+++ b/src/app/api/users/avatars/tests/route.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { requireAuthMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+}));
+
+vi.mock("@/server/auth/require-auth", () => ({
+  requireAuth: requireAuthMock,
+}));
+
+import { GET } from "../route";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("users avatars route", () => {
+  it("returns early when authentication fails", async () => {
+    const deniedResponse = Response.json(
+      { error: { code: "auth_required" } },
+      { status: 401 },
+    );
+    requireAuthMock.mockResolvedValueOnce({ response: deniedResponse });
+
+    const response = await GET(
+      new Request("http://localhost/api/users/avatars"),
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("uses authenticated storage client and filters admin profiles", async () => {
+    const createSignedUrlsWithAuthClientMock = vi.fn().mockResolvedValue({
+      data: [
+        {
+          path: "user-1/avatar.png",
+          signedUrl: "https://example.test/user-1-avatar",
+        },
+      ],
+      error: null,
+    });
+    const authClientStorageFromMock = vi.fn(() => ({
+      createSignedUrls: createSignedUrlsWithAuthClientMock,
+    }));
+
+    const createSignedUrlsWithDataClientMock = vi.fn();
+    const dataClientStorageFromMock = vi.fn(() => ({
+      createSignedUrls: createSignedUrlsWithDataClientMock,
+    }));
+
+    const orderMock = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: "user-1",
+          username: "Alice",
+          avatar_path: "user-1/avatar.png",
+          role: "user",
+        },
+        {
+          id: "admin-1",
+          username: "Admin",
+          avatar_path: "admin-1/avatar.png",
+          role: "admin",
+        },
+        {
+          id: "user-2",
+          username: "Bob",
+          avatar_path: null,
+          role: "user",
+        },
+      ],
+      error: null,
+    });
+    const limitMock = vi.fn(() => ({ order: orderMock }));
+    const selectMock = vi.fn(() => ({ limit: limitMock }));
+    const fromMock = vi.fn(() => ({ select: selectMock }));
+
+    requireAuthMock.mockResolvedValueOnce({
+      context: {
+        client: {
+          from: fromMock,
+          storage: {
+            from: dataClientStorageFromMock,
+          },
+        },
+        authClient: {
+          storage: {
+            from: authClientStorageFromMock,
+          },
+        },
+      },
+    });
+
+    const response = await GET(
+      new Request("http://localhost/api/users/avatars?limit=50"),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(fromMock).toHaveBeenCalledWith("profiles");
+    expect(selectMock).toHaveBeenCalledWith("id, username, avatar_path, role");
+    expect(limitMock).toHaveBeenCalledWith(50);
+    expect(orderMock).toHaveBeenCalledWith("username", { ascending: true });
+
+    expect(authClientStorageFromMock).toHaveBeenCalledWith("profile-images");
+    expect(createSignedUrlsWithAuthClientMock).toHaveBeenCalledWith(
+      ["user-1/avatar.png"],
+      600,
+    );
+    expect(createSignedUrlsWithDataClientMock).not.toHaveBeenCalled();
+    expect(dataClientStorageFromMock).not.toHaveBeenCalled();
+
+    expect(body).toEqual({
+      data: [
+        {
+          id: "user-1",
+          username: "Alice",
+          avatarPath: "user-1/avatar.png",
+          avatarUrl: "https://example.test/user-1-avatar",
+        },
+        {
+          id: "user-2",
+          username: "Bob",
+          avatarPath: null,
+          avatarUrl: null,
+        },
+      ],
+    });
+  });
+});

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -8,6 +8,7 @@ export const appRoutes = {
   authResetPassword: "/auth/reset-password",
   characters: "/characters",
   campaigns: "/campaigns",
+  usersAvatars: "/users/avatars",
   notifications: "/notifications",
   profile: "/profile",
   settings: "/settings",
@@ -22,6 +23,7 @@ export const appRoutes = {
 export const appNavigationRoutes = [
   { href: appRoutes.characters, key: "ui.menu.characters" },
   { href: appRoutes.campaigns, key: "ui.menu.campaigns" },
+  { href: appRoutes.usersAvatars, key: "ui.menu.avatars" },
 ] as const;
 
 type AppRouterProps = {

--- a/src/app/users/avatars/page.tsx
+++ b/src/app/users/avatars/page.tsx
@@ -1,0 +1,7 @@
+import { getRequestLocale } from "@/lib/i18n/request-locale";
+import { UsersAvatarsPageView } from "@/page-modules/users-avatars-page";
+
+export default async function UsersAvatarsPage() {
+  const locale = await getRequestLocale();
+  return <UsersAvatarsPageView locale={locale} />;
+}

--- a/src/features/users/queries/tests/users-avatar-list.query.test.ts
+++ b/src/features/users/queries/tests/users-avatar-list.query.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiRequestMock, unwrapApiResponseMock } = vi.hoisted(() => ({
+  apiRequestMock: vi.fn(),
+  unwrapApiResponseMock: vi.fn(),
+}));
+
+vi.mock("@/lib/client/api", () => ({
+  apiRequest: apiRequestMock,
+  unwrapApiResponse: unwrapApiResponseMock,
+}));
+
+import { getUsersAvatarList } from "../users-avatar-list.query";
+
+const session = {
+  accessToken: "access-token",
+  refreshToken: "refresh-token",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  unwrapApiResponseMock.mockImplementation(
+    (response: { data: unknown }) => response.data,
+  );
+});
+
+describe("users avatar list query", () => {
+  it("loads user avatars from the dedicated endpoint", async () => {
+    const response = {
+      data: [
+        {
+          id: "user-1",
+          username: "Alice",
+          avatarPath: "user-1/avatar.png",
+          avatarUrl: "https://example.test/user-1-avatar",
+        },
+      ],
+      error: null,
+      status: 200,
+    };
+    apiRequestMock.mockResolvedValueOnce(response);
+
+    await expect(getUsersAvatarList(session)).resolves.toEqual(response.data);
+    expect(apiRequestMock).toHaveBeenCalledWith(
+      "/api/users/avatars?limit=1000",
+      {
+        session,
+      },
+    );
+    expect(unwrapApiResponseMock).toHaveBeenCalledWith(
+      response,
+      "Failed to load user avatars",
+    );
+  });
+});

--- a/src/features/users/queries/users-avatar-list.query.ts
+++ b/src/features/users/queries/users-avatar-list.query.ts
@@ -1,0 +1,15 @@
+import { apiRequest, unwrapApiResponse } from "@/lib/client/api";
+import type { ClientSession } from "@/lib/client/session";
+import type { UserAvatarListEntry } from "@/features/users/types";
+
+export async function getUsersAvatarList(
+  session: ClientSession,
+): Promise<UserAvatarListEntry[]> {
+  const response = await apiRequest<UserAvatarListEntry[]>(
+    "/api/users/avatars?limit=1000",
+    {
+      session,
+    },
+  );
+  return unwrapApiResponse(response, "Failed to load user avatars");
+}

--- a/src/features/users/types.ts
+++ b/src/features/users/types.ts
@@ -96,3 +96,10 @@ export type UserListEntry = {
   username: string;
   role?: "user" | "admin";
 };
+
+export type UserAvatarListEntry = {
+  id: string;
+  username: string;
+  avatarPath: string | null;
+  avatarUrl: string | null;
+};

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -7,6 +7,7 @@
     "menu": {
       "characters": "Charaktere",
       "campaigns": "Kampagnen",
+      "avatars": "Avatare",
       "notifications": "Benachrichtigungen",
       "profile": "Profil",
       "settings": "Einstellungen",
@@ -62,6 +63,11 @@
     "userProfile": {
       "title": "Nutzerprofil",
       "subtitle": "Öffentliche Profildetails."
+    },
+    "usersAvatars": {
+      "title": "Nutzer-Avatare",
+      "subtitle": "Alle verfügbaren Profilbilder der Nutzer.",
+      "fallback": "Kein Avatar"
     },
     "settings": {
       "title": "Einstellungen",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -7,6 +7,7 @@
     "menu": {
       "characters": "Characters",
       "campaigns": "Campaigns",
+      "avatars": "Avatars",
       "notifications": "Notifications",
       "profile": "Profile",
       "settings": "Settings",
@@ -62,6 +63,11 @@
     "userProfile": {
       "title": "User profile",
       "subtitle": "Public profile details."
+    },
+    "usersAvatars": {
+      "title": "User avatars",
+      "subtitle": "All available user profile images.",
+      "fallback": "No avatar"
     },
     "settings": {
       "title": "Settings",

--- a/src/lib/client/query-keys.ts
+++ b/src/lib/client/query-keys.ts
@@ -24,6 +24,7 @@ export const queryKeys = {
     ["notifications", "list", token, limit] as const,
   notificationsUnreadCount: (token: string) =>
     ["notifications", "unread-count", token] as const,
+  usersAvatarList: (token: string) => ["users", "avatars", token] as const,
   usersPublicProfile: (userId: string, token: string) =>
     ["users", "public-profile", userId, token] as const,
 };

--- a/src/page-modules/users-avatars-page.tsx
+++ b/src/page-modules/users-avatars-page.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { AspectRatio } from "@/components/ui/aspect-ratio";
+import { AvatarImage } from "@/components/ui/avatar-image";
+import { EmptyState } from "@/components/ui/empty-state";
+import { FeedbackMessage } from "@/components/ui/feedback-message";
+import { UiDiv } from "@/components/ui/html-elements";
+import { ListItemRow } from "@/components/ui/list-item-row";
+import { PageLoadingState } from "@/components/ui/page-loading-state";
+import { AppPageMain, PageViewport } from "@/components/ui/page-shell";
+import { PaginationControls } from "@/components/ui/pagination-controls";
+import { TextLink } from "@/components/ui/text-link";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { appRoutes } from "@/app/router";
+import { getUsersAvatarList } from "@/features/users/queries/users-avatar-list.query";
+import { queryKeys } from "@/lib/client/query-keys";
+import { useClientSession } from "@/lib/client/use-client-session";
+import { getTranslator, type AppLocale } from "@/lib/i18n/index";
+import { hasItems } from "@/lib/logic/collections";
+import {
+  clampListPage,
+  DEFAULT_LIST_PAGE_SIZE,
+  paginateListItems,
+} from "@/lib/utils/list";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+type UsersAvatarsPageViewProps = {
+  locale: AppLocale;
+};
+
+export function UsersAvatarsPageView({ locale }: UsersAvatarsPageViewProps) {
+  const t = useMemo(() => getTranslator(locale), [locale]);
+  const router = useRouter();
+  const { session, ready } = useClientSession();
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    if (!ready) {
+      return;
+    }
+
+    if (!session) {
+      router.replace(appRoutes.home);
+    }
+  }, [ready, router, session]);
+
+  const usersAvatarListQuery = useQuery({
+    queryKey: queryKeys.usersAvatarList(session?.accessToken ?? "no-session"),
+    enabled: Boolean(session),
+    staleTime: 240_000,
+    queryFn: async () => {
+      if (!session) {
+        throw new Error("Missing session");
+      }
+
+      return getUsersAvatarList(session);
+    },
+  });
+
+  if (!ready || !session) {
+    return <PageViewport />;
+  }
+
+  if (usersAvatarListQuery.isLoading) {
+    return (
+      <AppPageMain maxWidth="7xl">
+        <PageLoadingState label={t("ui.loading.page")} />
+      </AppPageMain>
+    );
+  }
+
+  const usersAvatarList = usersAvatarListQuery.data ?? [];
+  const safePage = clampListPage(
+    page,
+    usersAvatarList.length,
+    DEFAULT_LIST_PAGE_SIZE,
+  );
+  const pagedUsersAvatarList = paginateListItems(
+    usersAvatarList,
+    safePage,
+    DEFAULT_LIST_PAGE_SIZE,
+  );
+
+  const errorMessage =
+    usersAvatarListQuery.error instanceof Error
+      ? usersAvatarListQuery.error.message
+      : "";
+
+  return (
+    <AppPageMain maxWidth="7xl">
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("ui.usersAvatars.title")}</CardTitle>
+          <CardDescription>{t("ui.usersAvatars.subtitle")}</CardDescription>
+        </CardHeader>
+        <CardContent stack={4}>
+          <FeedbackMessage message={errorMessage} />
+
+          <UiDiv stack={2}>
+            {pagedUsersAvatarList.map((user) => (
+              <ListItemRow key={user.id}>
+                <UiDiv stack={1}>
+                  <UiDiv surface="avatar-frame">
+                    {user.avatarUrl ? (
+                      <AvatarImage src={user.avatarUrl} alt={user.username} />
+                    ) : (
+                      <AspectRatio ratio={1}>
+                        <UiDiv surface="avatar-fallback">
+                          {t("ui.usersAvatars.fallback")}
+                        </UiDiv>
+                      </AspectRatio>
+                    )}
+                  </UiDiv>
+                  <TextLink href={`/users/${user.id}`}>
+                    {user.username}
+                  </TextLink>
+                </UiDiv>
+              </ListItemRow>
+            ))}
+            {!hasItems(usersAvatarList) ? (
+              <EmptyState label={t("ui.feedback.empty")} />
+            ) : null}
+          </UiDiv>
+
+          <PaginationControls
+            page={safePage}
+            pageSize={DEFAULT_LIST_PAGE_SIZE}
+            totalItems={usersAvatarList.length}
+            previousLabel={t("ui.list.previous")}
+            nextLabel={t("ui.list.next")}
+            pageLabel={t("ui.list.page")}
+            onPageChange={setPage}
+          />
+        </CardContent>
+      </Card>
+    </AppPageMain>
+  );
+}


### PR DESCRIPTION
## Summary

- Add a new authenticated `/users/avatars` page and page module to display all user avatars with loading, error, empty, and fallback states.
- Add a dedicated server route `GET /api/users/avatars` that returns non-admin profiles and resolves avatar signed URLs in batch via authenticated storage client usage.
- Add users avatar query/types/query-key wiring, i18n labels (`en`/`de`), app navigation entry, API/query tests, and screenshot-target policy mappings for the new route.

## Linked Issue(s)

- #67

## Flow Impact

- [ ] No user-flow impact
- [ ] Existing flow changed
- [x] New flow added

## Impact Signals (Regression Auto-Label)

- [ ] Security impact
- [ ] Data model impact
- [ ] Performance impact

## E2E Coverage Matrix

| AC / User Flow Ref                                      | Scenario ID                              | Test status | Why E2E vs feature test                                                     |
| ------------------------------------------------------- | ---------------------------------------- | ----------- | ---------------------------------------------------------------------------- |
| Avatar overview reachable for authenticated app sessions | FLOW-auth-user-registration-login-logout | Existing    | Authenticated navigation/session behavior is already covered in smoke E2E. |

## PR Acceptance Criteria (Required When No Linked Issue)

- N/A (linked issue exists)

## PR Happy Paths (Required When No Linked Issue)

- N/A (linked issue exists)

## Scope

- [x] One coherent change package
- [x] Branch created from latest `main`

## Verification

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test:run`
- [x] `yarn build` (required for release-impacting changes)
- [ ] `yarn test:e2e --grep @smoke` (for flow-impacting changes)

## Documentation

- [x] Relevant docs updated when conventions/behavior changed
- [x] ADR linked or rationale given when architecture/security/runtime boundaries changed

No architecture/security/runtime boundary changes requiring ADR updates.

## Risk and Rollback

- Risk notes:
  - New API endpoint and page could regress avatar rendering if signed URL generation fails.
  - Added route mapping in screenshot policy config can affect CI policy checks if changed inconsistently later.
- Rollback approach:
  - Revert commit `ae61dbd` to remove route/page/query wiring and restore previous navigation/policy state.

## Agent Automation Safety (when applicable)

- [x] No sandbox/approval bypass flags used
- [x] High-risk or destructive overrides (`--confirm-risky`, `--allow-destructive`) documented with rationale
